### PR TITLE
Use SIGTERM instead of SIGQUIT to Force Quit

### DIFF
--- a/QSProcessManipulationPlugInAction.m
+++ b/QSProcessManipulationPlugInAction.m
@@ -88,7 +88,7 @@ return nil;
 }
 
 - (QSObject *) killProcess:(QSObject *)dObject{
-	[self sendSignal:SIGKILL toProcess:dObject];
+	[self sendSignal:SIGTERM toProcess:dObject];
 	return nil;
 }
 - (QSObject *) suspendProcess:(QSObject *)dObject{

--- a/QSProcessManipulationPlugInAction.m
+++ b/QSProcessManipulationPlugInAction.m
@@ -88,7 +88,7 @@ return nil;
 }
 
 - (QSObject *) killProcess:(QSObject *)dObject{
-	[self sendSignal:SIGQUIT toProcess:dObject];
+	[self sendSignal:SIGKILL toProcess:dObject];
 	return nil;
 }
 - (QSObject *) suspendProcess:(QSObject *)dObject{


### PR DESCRIPTION
SIGKILL is clean and nice. It's what the Force Quit dialog box uses. Sending SIGQUIT causes nasty crash reports every time.
